### PR TITLE
Business Link and Directgov logos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rack-statsd', '0.1.1'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '1.2.4'
+  gem 'slimmer', '2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,8 +138,7 @@ GEM
     simplecov-html (0.4.5)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (1.2.4)
-      gds-api-adapters (>= 0.0.33, < 0.3.0)
+    slimmer (2.0.0)
       json
       nokogiri (~> 1.5.0)
       null_logger
@@ -197,7 +196,7 @@ DEPENDENCIES
   shoulda (= 2.11.3)
   simplecov (= 0.4.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 1.2.4)
+  slimmer (= 2.0.0)
   statsd-ruby (= 1.0.0)
   test-unit (= 2.4.2)
   therubyracer (= 0.10.2)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,11 +1,18 @@
+require 'gds_api/helpers'
+
 class PlansController < ApplicationController
+  include GdsApi::Helpers
   before_filter :find_planner
 
   def show
     expires_in 24.hours, :public => true unless Rails.env.development?
     if @planner
       respond_to do |format|
-        format.html { render "show_#{@planner.class.slug}" }
+        format.html do
+          @artefact = fetch_artefact(slug: params[:id])
+          set_slimmer_artefact(@artefact)
+          render "show_#{@planner.class.slug}"
+        end
         if @planner.errors.any? || @planner.key_dates.nil?
           format.any(:xml, :json, :ics) { head 400 }
         else

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,20 +1,13 @@
 require 'test_helper'
 require 'capybara/rails'
+require 'slimmer/test'
+require 'gds_api/test_helpers/panopticon'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-end
+  include GdsApi::TestHelpers::Panopticon
 
-# Tell all requests to skip slimmer
-class ActionController::Base
-  before_filter proc {
-    response.headers[Slimmer::SKIP_HEADER] = "true"
-  }
-end
-
-Capybara.default_driver = :webkit
-Capybara.app = Rack::Builder.new do
-  map "/" do
-    run Capybara.app
+  setup do
+    stub_panopticon_default_artefact
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,3 +31,5 @@ module AssertPresent
   end
 
 end
+
+require 'webmock/test_unit'


### PR DESCRIPTION
Update to slimmer 2.0 to set classes for businesslink and directgov logos.  alphagov/static#20 should be merged first.
